### PR TITLE
Fix Aggregation git ref

### DIFF
--- a/fuse/community/aggregation/booster.yaml
+++ b/fuse/community/aggregation/booster.yaml
@@ -3,13 +3,13 @@ description: Booster to expose an HTTP REST endpoint using Apache Camel where th
 source:
   git:
     url: https://github.com/integr8ly/fuse-flights-aggregator
-    ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+    ref: release-1.2.2
 environment:
   staging:
     source:
       git:
-        ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+        ref: release-1.2.2
   production:
     source:
       git:
-        ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+        ref: release-1.2.2

--- a/fuse/redhat/aggregation/booster.yaml
+++ b/fuse/redhat/aggregation/booster.yaml
@@ -3,13 +3,13 @@ description: Booster to expose an HTTP REST endpoint using Apache Camel where th
 source:
   git:
     url: https://github.com/integr8ly/fuse-flights-aggregator
-    ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+    ref: release-1.2.2
 environment:
   staging:
     source:
       git:
-        ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+        ref: release-1.2.2
   production:
     source:
       git:
-        ref: f26b75349bf3aa8cffe8f4d68374099eece02f8b
+        ref: release-1.2.2


### PR DESCRIPTION
## Motivation
Apparently, hashes are not supported. This will fix following error when creating Aggregation app:
```
2019-03-20 11:30:15,634 INFO  [NativeGitBoosterCatalogPathProvider] (EE-ManagedExecutorService-default-Thread-2) 
Executing: git clone https://github.com/integr8ly/fuse-flights-aggregator  
--branch f26b75349bf3aa8cffe8f4d68374099eece02f8b --recursive --depth=1 --quiet -c advice.detachedHead=false /tmp/booster-catalog8609781243366068562/.boosters/fuse_redhat_aggregation_booster_production
warning: Could not find remote branch f26b75349bf3aa8cffe8f4d68374099eece02f8b to clone.
```

The tag has been created - https://github.com/integr8ly/fuse-flights-aggregator/tree/release-1.2.2
Related to: https://issues.jboss.org/browse/INTLY-1268