### PR TITLE
INTLY-7382 Bumped Red Hat Fuse from 7.5.0 to 7.6.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -124,7 +124,7 @@ runtimes:
       - id: community
         name: 2.21.2 (Community)
       - id: redhat
-        name: 7.5.0 (Red Hat Fuse)
+        name: 7.6.0 (Red Hat Fuse)
   - id: nodejs
     name: Node.js
     description: >-


### PR DESCRIPTION
Bumped Red Hat Fuse from 7.5.0 to 7.6.0
https://issues.redhat.com/browse/INTLY-7382

Relates to this PR
https://github.com/integr8ly/installation/pull/1341
